### PR TITLE
Fix CSV header fallback in file processing

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -292,7 +292,7 @@ const BSSCISAnalyzer = () => {
       const cisText = await readFileAsText(cisFile);
       const cisLines = cisText.split('\n');
       const dataStartIndex = cisLines.findIndex(line => line.includes('check_id'));
-      const cisDataOnly = cisLines.slice(dataStartIndex).join('\n');
+      const cisDataOnly = cisLines.slice(dataStartIndex === -1 ? 0 : dataStartIndex).join('\n');
       
       const cisParsed = Papa.parse(cisDataOnly, {
         header: true,


### PR DESCRIPTION
## Summary
- fallback if `check_id` header not found when parsing CIS CSV

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fae04b3b8832aaf6da9c0d3adc623